### PR TITLE
Set SECRET_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Add your secrets here. E.g.
 # My Project Vault File
 
 vault_default_db_password: SuperSecret
+vault_django_secret_key: als0_SEcr3t
 ```
 
 You run the following to edit the file later:

--- a/roles/commcare_sync/defaults/main.yml
+++ b/roles/commcare_sync/defaults/main.yml
@@ -51,6 +51,7 @@ default_db_host: 127.0.0.1
 default_db_port: 5432
 
 django_settings_module: "{{ app_name }}.settings"
+django_secret_key: "{{ vault_django_secret_key }}"
 django_migrate: true
 django_collectstatic: true
 

--- a/roles/commcare_sync/templates/django/local.py.j2
+++ b/roles/commcare_sync/templates/django/local.py.j2
@@ -1,5 +1,9 @@
 from .settings import *
 
+{% if django_secret_key %}
+SECRET_KEY = '{{ django_secret_key }}'
+{% endif %}
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',


### PR DESCRIPTION
[Django uses SECRET_KEY for](https://docs.djangoproject.com/en/3.1/topics/signing/) generating password resets, session cookies, CSRF tokens, and stuff we don't want hijacked. Each deploy should have its own, and it should be secret.

This is a small change to allow it to be set in the Ansible vault file.
