### PR TITLE
Manage Postgres listen_addresses from Ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To develop and test, follow the instructions below.
 
 ### Set up Vagrant
 
-[Foollow this guide](https://www.vagrantup.com/docs/installation/)
+[Follow this guide](https://www.vagrantup.com/docs/installation/)
 
 ### Deploy to local VM
 

--- a/roles/commcare_sync/defaults/main.yml
+++ b/roles/commcare_sync/defaults/main.yml
@@ -43,7 +43,7 @@ superset_password: "{{ vault_default_superset_password }}"
 
 postgresql_version: 10
 postgresql_user: postgres
-postgresql_allow_remote_connections: yes
+postgresql_allow_remote_connections: no
 
 default_db_name: "{{ app_name }}"
 default_db_user: "{{ app_name }}"

--- a/roles/commcare_sync/defaults/main.yml
+++ b/roles/commcare_sync/defaults/main.yml
@@ -43,6 +43,7 @@ superset_password: "{{ vault_default_superset_password }}"
 
 postgresql_version: 10
 postgresql_user: postgres
+postgresql_allow_remote_connections: yes
 
 default_db_name: "{{ app_name }}"
 default_db_user: "{{ app_name }}"

--- a/roles/commcare_sync/templates/postgres/postgresql.conf.j2
+++ b/roles/commcare_sync/templates/postgres/postgresql.conf.j2
@@ -56,7 +56,12 @@ external_pid_file = '/var/run/postgresql/10-main.pid'			# write an extra PID fil
 
 # - Connection Settings -
 
+
+{% if postgresql_allow_remote_connections %}
 listen_addresses = '*' # what IP address(es) to listen on;
+{% else %}
+listen_addresses = 'localhost' # what IP address(es) to listen on;
+{% endif %}
 					             # comma-separated list of addresses;
 					             # defaults to 'localhost'; use '*' for all
 					             # (change requires restart)


### PR DESCRIPTION
This is a small change that allows `listen_addresses` in postgresql.conf to be managed from Ansible. It flips the default setting to the more secure option.

This is a non-issue for EC2 instances, because AWS will manage access to ports. And this change does not assign the value to a variable set under "inventories", but it does make it easy to switch to a variable if we want to.
