### PR TITLE
don't use jinja where we're not supposed to

### DIFF
--- a/roles/commcare_sync/tasks/main.yml
+++ b/roles/commcare_sync/tasks/main.yml
@@ -129,7 +129,7 @@
 # Superset
 
 - include_tasks: superset.yml
-  when: "{{ superset_enabled }}"
+  when: superset_enabled
   tags:
     - superset
     - superset-admin


### PR DESCRIPTION
fixes this warning: `[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ superset_enabled }}`