### PR TITLE
format tags properly

### DIFF
--- a/roles/commcare_sync/tasks/nginx.yml
+++ b/roles/commcare_sync/tasks/nginx.yml
@@ -7,8 +7,9 @@
     name: nginx
     update_cache: "{{ apt_update_cache }}"
     state: present
-  tags: packages
-  tags: nginx
+  tags:
+    - packages
+    - nginx
 
 - name: Start NGINX.
   service:


### PR DESCRIPTION
fixes `While constructing a mapping from /home/ansible/commcare-sync-ansible/roles/commcare_sync/tasks/nginx.yml, line 5, column 3, found a duplicate dict key (tags). Using last defined value only.`