### PR TITLE
use configured postgres version in config file

### DIFF
--- a/roles/commcare_sync/templates/postgres/postgresql.conf.j2
+++ b/roles/commcare_sync/templates/postgres/postgresql.conf.j2
@@ -38,15 +38,15 @@
 # The default values of these variables are driven from the -D command-line
 # option or PGDATA environment variable, represented here as ConfigDir.
 
-data_directory = '/var/lib/postgresql/10/main'		# use data in another directory
+data_directory = '/var/lib/postgresql/{{ postgresql_version }}/main'		# use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/10/main/pg_hba.conf'	# host-based authentication file
+hba_file = '/etc/postgresql/{{ postgresql_version }}/main/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/10/main/pg_ident.conf'	# ident configuration file
+ident_file = '/etc/postgresql/{{ postgresql_version }}/main/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.
-external_pid_file = '/var/run/postgresql/10-main.pid'			# write an extra PID file
+external_pid_file = '/var/run/postgresql/{{ postgresql_version }}-main.pid'			# write an extra PID file
 					# (change requires restart)
 
 
@@ -479,7 +479,7 @@ log_timezone = 'UTC'
 
 # - Process Title -
 
-cluster_name = '10/main'			# added to process titles if nonempty
+cluster_name = '{{ postgresql_version }}/main'			# added to process titles if nonempty
 					# (change requires restart)
 #update_process_title = on
 
@@ -495,7 +495,7 @@ cluster_name = '10/main'			# added to process titles if nonempty
 #track_io_timing = off
 #track_functions = none			# none, pl, all
 #track_activity_query_size = 1024	# (change requires restart)
-stats_temp_directory = '/var/run/postgresql/10-main.pg_stat_tmp'
+stats_temp_directory = '/var/run/postgresql/{{ postgresql_version }}-main.pg_stat_tmp'
 
 
 # - Statistics Monitoring -


### PR DESCRIPTION
without this change postgres can't start on any version other than 10.

@prem-fissionhq I noticed that access used version 11. did you not run into this setting up that server?