### PR TITLE
setting acl values on logs directory

### DIFF
--- a/roles/commcare_sync/tasks/django.yml
+++ b/roles/commcare_sync/tasks/django.yml
@@ -64,6 +64,10 @@
     - "{{ static_dir }}"
     - "{{ media_dir }}"
 
+- name: set acl on app log directory.
+  shell: setfacl -d -m u::rwx,g::rw,o::rw {{ item }}
+  with_items:
+    - "{{ log_dir }}"
 
 # Django
 


### PR DESCRIPTION
To avoid permission denied issues after the supervisor performed log rotation, setting up ACLs with default write permissions to all the new files that are created inside the folder. 
Right now, permissions are given only to root:root, and other users are unable to write to the file due to insufficient permissions on the log file. 

@czue Please let me know if you have any questions.  
Thanks.