### PR TITLE
Add DVS environment and fix setup

### DIFF
--- a/roles/commcare_sync/defaults/main.yml
+++ b/roles/commcare_sync/defaults/main.yml
@@ -66,6 +66,7 @@ app_environment:
 superset_environment:
   SQLALCHEMY_DATABASE_URI: 'postgresql://{{ default_db_user }}:{{ default_db_password }}@{{ default_db_host }}:{{ default_db_port }}/{{ superset_db_name }}'
   FLASK_APP: superset
+  SUPERSET_CONFIG_PATH: '{{ superset_project_dir }}/superset_config.py'
 
 gunicorn_num_workers: 3
 gunicorn_max_requests: 0

--- a/roles/commcare_sync/tasks/letsencrypt_cert.yml
+++ b/roles/commcare_sync/tasks/letsencrypt_cert.yml
@@ -18,7 +18,7 @@
     name:
       - software-properties-common
       - certbot
-      - python-certbot-nginx
+      - python3-certbot-nginx
   ignore_errors: '{{ ansible_check_mode }}'
   when: ssl_enabled or superset_ssl_enabled
   tags: letsencrypt


### PR DESCRIPTION
This PR was mainly intended to add a [new environment](https://github.com/dimagi/commcare-sync-inventories/pull/3).
Found couple of issues that were fixed.

1. The config path was not set when setting up superset, leading the installation to use default sqlite3 db and not the one expected by the setup
2. We are using python3 so use the corresponding package for letsencrypt

Setup steps noted down in https://docs.google.com/document/d/1oBCkQNHRosY5tzJTWzmrACNyDCdQVdLMpTiBmep0iKU/edit#