### PR TITLE
More fail-proof copy commands

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -45,7 +45,8 @@ First create a new inventory folder for your environment (we'll use `myproject` 
 This is where your project-specific configuration will live. 
 
 ```bash
-cp -r inventories/example inventories/myproject
+mkdir -p inventories/myproject
+cp -r inventories/example/* inventories/myproject
 ```
 #### Update Inventory Files
 


### PR DESCRIPTION
People are [making the mistake](https://forum.dimagi.com/t/error-deploying-commcare-sync-instance/9157) of creating `inventories/myproject/example` instead of `inventories/myproject` directory.  This should avoid that.