### PR TITLE
Allow setting commcare_default_server

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -58,7 +58,8 @@ Edit the following files with your project-specific changes:
 * `inventories/myproject/group_vars/commcare_sync/vars.yml`
     * `public_host`: your commcare-sync hostname
     * `superset_public_host`: your superset hostname
-    * `superset_enabled`: specifies whether Superset should be installed 
+    * `superset_enabled`: specifies whether Superset should be installed
+    * `commcare_default_server`: (Optional) Full URL of HQ environment for projects. Default: https://www.commcarehq.org
 
 #### Ansible Vault
 

--- a/roles/commcare_sync/defaults/main.yml
+++ b/roles/commcare_sync/defaults/main.yml
@@ -28,6 +28,7 @@ media_dir: "{{ src_dir }}/media"
 
 commcare_sync_export_periodicity: 43200  # 60 * 60 * 12 = every 12 hours
 project_timezone: 'America/New_York'
+commcare_default_server: 'https://www.commcarehq.org'
 
 # superset defaults
 superset_enabled: yes

--- a/roles/commcare_sync/templates/django/local.py.j2
+++ b/roles/commcare_sync/templates/django/local.py.j2
@@ -30,3 +30,5 @@ DEBUG = False
 
 COMMCARE_SYNC_EXPORT_PERIODICITY = {{ commcare_sync_export_periodicity }}
 TIME_ZONE = '{{ project_timezone }}'
+
+COMMCARE_DEFAULT_SERVER = '{{ commcare_default_server }}'


### PR DESCRIPTION
This adds the ability to configure the HQ environment URL for commcare-sync setup.