### PR TITLE
Allow multiple public superset hosts

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -58,6 +58,7 @@ Edit the following files with your project-specific changes:
 * `inventories/myproject/group_vars/commcare_sync/vars.yml`
     * `public_host`: your commcare-sync hostname
     * `superset_public_host`: your superset hostname
+    * `superset_public_hosts`: a list of superset hostnames. This overrides superset_public_host
     * `superset_enabled`: specifies whether Superset should be installed
     * `commcare_default_server`: (Optional) Full URL of HQ environment for projects. Default: https://www.commcarehq.org
 

--- a/roles/commcare_sync/templates/nginx/superset_nginx_without_ssl_config.j2
+++ b/roles/commcare_sync/templates/nginx/superset_nginx_without_ssl_config.j2
@@ -13,7 +13,11 @@ upstream superset {
 
 server {
   # Serve content
+  {% if superset_public_hosts is defined %}
+  server_name {% for public_host in superset_public_hosts %} {{ public_host }} {% endfor %};
+  {% else %}
   server_name {{ superset_public_host }};
+  {% endif %}
   listen 80;
   listen [::]:80;
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/INDIV-173

This change let's someone set different URLs for the same instance.
This is useful when different projects are setup on an instance and they want their own custom link.

Tested that the setup works okay with this change.