### PR TITLE
Backup retention on s3 based on file count

### DIFF
--- a/inventories/example/group_vars/commcare_sync/vars.yml
+++ b/inventories/example/group_vars/commcare_sync/vars.yml
@@ -11,6 +11,7 @@ django_settings_module: "{{ app_name }}.local"
 postgresql_backup_enabled: false
 # Add any other DBs separated with spaces
 postgresql_backup_db_list: "superset"
+postgresql_backups_to_keep: 5  # 0 will ignore this setting
 
 # vault_ variables are stored in vault.yml file (pw: "secret")
 ...

--- a/roles/commcare_sync/templates/postgres/create_postgres_dump.sh.j2
+++ b/roles/commcare_sync/templates/postgres/create_postgres_dump.sh.j2
@@ -53,4 +53,26 @@ if [[ $? -ne 0 ]] ; then
     exit 1
 fi
 
+N_BACKUPS="{{ postgresql_backups_to_keep }}"
+if [ "$N_BACKUPS" -gt 0 ]; then
+    log "Checking for backups to remove";
+    # List objects matching the pattern and capture the result in a variable
+    objects_to_delete=$(aws s3api list-objects --bucket "{{ secrets.s3_bucket }}" --query "Contents[?starts_with(Key, 'postgres_backup_')].[Key, LastModified]" --output text | \
+      sort -k2 | \
+      head -n -$N_BACKUPS)
+
+    # Check if there are any objects to delete
+    if [ -n "$objects_to_delete" ]; then
+      echo "Deleting objects"
+      # Format the object keys into the necessary JSON structure and delete the objects
+      echo "$objects_to_delete" | \
+        awk '{print "{\"Key\":\"" $1 "\"}"}' | \
+        paste -sd, | \
+        sed 's/^/{"Objects":[/;s/$/]}/' | \
+        aws s3api delete-objects --bucket "{{ secrets.s3_bucket }}" --delete file:///dev/stdin
+    else
+      echo "No objects found to delete."
+    fi
+fi
+
 exit 0


### PR DESCRIPTION
Implements retention of backup files on s3 based on file count.
The retention logic is copied over from [this PR](https://github.com/dimagi/commcare-analytics-ansible/pull/50).

It has been tested in the above PR and is currently being used for CCA backups.