### PR TITLE
Set the HTTP_HOST header to the server name

### DIFF
--- a/roles/commcare_sync/templates/nginx/gunicorn_nginx_without_ssl_config.j2
+++ b/roles/commcare_sync/templates/nginx/gunicorn_nginx_without_ssl_config.j2
@@ -33,7 +33,7 @@ server {
   location / {
 
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $http_host;
+    proxy_set_header Host $server_name;
     proxy_read_timeout {{ gunicorn_timeout_seconds }}s;
     proxy_redirect off;
 


### PR DESCRIPTION
1. Ensures that HTTP_HOST header matches ALLOWED_HOSTS
2. Avoids host header attacks https://portswigger.net/web-security/host-header